### PR TITLE
Add No-Parameter Endpoint for GeoIP Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This is a fork of Malith-Rukshan/geoip-api. I added the ability to do self-lookups, that is look up the geolocation of the sender's IP. This was used for geolocating the closest STUN servers for my other project: [FileFerry](https://github.com/smp46/FileFerry).
+
 <p style="text-align:center;" align="center">
   <img align="center" src="https://raw.githubusercontent.com/Malith-Rukshan/geoip-api/refs/heads/main/api/static/img/logo.png" alt="GeoIP API" width="300px" height="300px"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ https://your-domain.com/8.8.8.8
 
 # Query parameter
 https://your-domain.com/?ip=8.8.8.8
+
+# No parameter (uses the client's IP address) 
+https://your-domain.com/
 ```
 
 #### Standard API Endpoint

--- a/README.md
+++ b/README.md
@@ -2,36 +2,30 @@
 > This is a fork of Malith-Rukshan/geoip-api. I added the ability to do self-lookups, that is look up the geolocation of the sender's IP. This was used for geolocating the closest STUN servers for my other project: [FileFerry](https://github.com/smp46/FileFerry).
 
 <p style="text-align:center;" align="center">
-  <img align="center" src="https://raw.githubusercontent.com/Malith-Rukshan/geoip-api/refs/heads/main/api/static/img/logo.png" alt="GeoIP API" width="300px" height="300px"/>
+  <img align="center" src="https://raw.githubusercontent.com/smp46/geoip-api/refs/heads/main/api/static/img/logo.png" alt="GeoIP API" width="300px" height="300px"/>
 </p>
 <h1 align="center">GeoIP API</h1>
-<div align='center'>
 
-[![PyPI Package](https://img.shields.io/badge/PyPI-geoip--py-4B8BBE?logo=pypi&style=flat)](https://pypi.org/project/geoip-py/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-Demo-009688?logo=fastapi&style=flat)](https://geoip-api.malith.dev/)
-[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&style=flat)](https://hub.docker.com/r/malithrukshan/geoip-api)
-</div>
-
-<h4 align="center">✨ A self-hosted IP geolocation API and Python package that works completely offline! 🚀</h4>
+<h4 align="center"> A self-hosted IP geolocation API and Python package that works completely offline! 🚀</h4>
 
 <div align="center">
   - Deploy your own private GeoIP service with complete control over your data and infrastructure -
   <br/>
-  <sup><sub>Powered by MaxMind's GeoLite2 databases ツ</sub></sup>
+  <sup><sub>Powered by MaxMind's GeoLite2 databases </sub></sup>
 </div>
 
-## ✨ Features
+##  Features
 
-- 🌍 Fast and reliable IP geolocation lookups
-- 🔒 Self-hosted solution with no external API dependencies
-- 🛠️ Dual functionality: Python package and REST API
-- 🐳 Easy deployment with Docker and cloud platforms
-- 📊 Get country, city, coordinates, timezone, ISP, and ASN data
-- 🎨 Beautiful, interactive demo UI for testing
-- 🚀 Built with FastAPI for high performance
-- 📦 Automatic GeoLite2 database downloads and updates
+- Fast and reliable IP geolocation lookups
+- Self-hosted solution with no external API dependencies
+- Dual functionality: Python package and REST API
+- Easy deployment with Docker and cloud platforms
+- Get country, city, coordinates, timezone, ISP, and ASN data
+- Beautiful, interactive demo UI for testing
+- Built with FastAPI for high performance
+- Automatic GeoLite2 database downloads and updates
 
-## 🛠️ Usage
+##  Usage
 
 ### Python Package
 
@@ -70,11 +64,7 @@ print(result)
 # }
 ```
 
-### REST API
-
-✅ Demo : https://geoip-api.malith.dev/
-
-#### Simple Endpoints
+#### Endpoints
 
 ```
 # Simple path parameter
@@ -112,21 +102,10 @@ https://your-domain.com/api/v1/geoip/lookup/8.8.8.8
 }
 ```
 
-## 📦 Deployment Options
+##  Deployment Options
 
-### 🚀 Cloud Deployment
+### Docker
 
-One-click deployment to popular platforms:
-
-[![Deploy with heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/Malith-Rukshan/geoip-api)
-
-[![Deploy to Railway](https://railway.app/button.svg)](https://railway.app/template/6zn6HZ)
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Malith-Rukshan/geoip-api)
-
-### 🐳 Docker
-
-The fastest way to deploy your own GeoIP API:
 
 ```bash
 docker pull malithrukshan/geoip-api
@@ -159,13 +138,13 @@ Then run:
 docker-compose up -d
 ```
 
-### 🔨 Building Docker Image Locally
+### Building Docker Image Locally
 
 If you want to build and run the Docker image from source:
 
 1. Clone the repository
    ```bash
-   git clone https://github.com/Malith-Rukshan/geoip-api.git
+   git clone https://github.com/smp46/geoip-api.git
    cd geoip-api
    ```
 2. Build the Docker image
@@ -178,7 +157,7 @@ If you want to build and run the Docker image from source:
    ```
 4. Access the API at http://localhost:8000
 
-## 💻 Local Development
+## Local Development
 
 ### Prerequisites
 
@@ -189,7 +168,7 @@ If you want to build and run the Docker image from source:
 
 1. Clone the repository
    ```bash
-   git clone https://github.com/Malith-Rukshan/geoip-api.git
+   git clone https://github.com/smp46/geoip-api.git
    cd geoip-api
    ```
 
@@ -221,50 +200,21 @@ black --check src tests api
 mypy src tests api
 ```
 
-## 🌐 Use Cases
 
-- **Security & Compliance**: Enhance security systems with IP-based threat detection while maintaining data sovereignty
-- **Content Localization**: Deliver region-specific content based on visitor location without sharing user data
-- **Analytics**: Analyze traffic patterns and user demographics with geographic data that remains within your infrastructure
-- **Fraud Prevention**: Identify suspicious login attempts based on geographic anomalies
-- **Development Environment**: Use a local GeoIP service in your development environment without external API dependencies
-
-## 📜 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## ⚠️ Database License Notice
+## Database License Notice
 
 This project uses GeoLite2 data created by MaxMind, available from [https://www.maxmind.com](https://www.maxmind.com). The GeoLite2 databases are licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 
-## 🔧 Acknowledgements
+## Acknowledgements
 
 - GeoLite2 databases provided by [MaxMind](https://www.maxmind.com)
 - Mirror of GeoLite2 databases maintained by [P3TERX](https://github.com/P3TERX/GeoLite.mmdb)
 - Built with [FastAPI](https://fastapi.tiangolo.com/) and [Python](https://www.python.org/)
 - Powered by [geoip2](https://github.com/maxmind/GeoIP2-python) library
 
-### 🇺🇳 Flags By : [Animated Country Flags](https://github.com/Malith-Rukshan/animated-country-flags)
+###  Flags By : [Animated Country Flags](https://github.com/Malith-Rukshan/animated-country-flags)
 
-## 🤝 Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 🌟 Support and Community
-
-If you found this project helpful, please give it a ⭐ on GitHub. This helps more developers discover the project! 🫶
-
-## 📬 Contact
-
-If you have any questions, feedback, or just want to say hi, you can reach out to me:
-
-- Email: [hello@malith.dev](mailto:hello@malith.dev)
-- GitHub: [@Malith-Rukshan](https://github.com/Malith-Rukshan)
-
-🧑‍💻 Built with 💖 by [Malith Rukshan](https://github.com/Malith-Rukshan)


### PR DESCRIPTION
These changes allow users to perform IP geolocation lookups without specifying an IP address, defaulting to using the client's IP. For example, https://your-domain.com/ will now return geolocation data based on the requester’s IP address.

I also made sure to check if the client IP belongs to an internal Docker Network. If it does, it will try to get the IP from the "X-Forwarded-For" header. This way if running behind Docker (and not wanting to use network_mode:host) the container can be put behind a Reverse Proxy and still function as expected.